### PR TITLE
Parent for Locked Form

### DIFF
--- a/src/Vcl.BlockUI.pas
+++ b/src/Vcl.BlockUI.pas
@@ -35,7 +35,8 @@ begin
   FLockedForm.Top := FLockedComponent.Top;
   FLockedForm.Height := FLockedComponent.Height;
   FLockedForm.Width := FLockedComponent.Width;
-  FLockedForm.Parent := FLockedComponent;
+  if FLockedComponent <> Application.MainForm then
+    FLockedForm.Parent := FLockedComponent;    
   FLockedForm.Show;
 end;
 


### PR DESCRIPTION
The locked form must not has a parente when is the main form of the application, because if you are showing any other form in modal mode he will not be locked.